### PR TITLE
Support rendering directly to an io.Writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you're planning to render the same template multiple times, you do it efficie
 tmpl, _ := mustache.ParseString("hello {{c}}")
 var buf bytes.Buffer
 for i := 0; i < 10; i++ {
-    tmpl.Render(map[string]string{"c": "world"}, &buf)
+    tmpl.FRender(&buf, map[string]string{"c": "world"})
 }
 ```
 

--- a/mustache.go
+++ b/mustache.go
@@ -604,14 +604,26 @@ func (tmpl *Template) Render(context ...interface{}) (string, error) {
 // render the compiled template and layout "wrapper" template and return the
 // output.
 func (tmpl *Template) RenderInLayout(layout *Template, context ...interface{}) (string, error) {
-	content, err := tmpl.Render(context...)
+	var buf bytes.Buffer
+	err := tmpl.FRenderInLayout(&buf, layout, context...)
 	if err != nil {
 		return "", err
+	}
+	return buf.String(), nil
+}
+
+// FRenderInLayout uses the given data source - generally a map or
+// struct - to render the compiled templated a loayout "wrapper"
+// template to an io.Writer.
+func (tmpl *Template) FRenderInLayout(out io.Writer, layout *Template, context ...interface{}) error {
+	content, err := tmpl.Render(context...)
+	if err != nil {
+		return err
 	}
 	allContext := make([]interface{}, len(context)+1)
 	copy(allContext[1:], context)
 	allContext[0] = map[string]string{"content": content}
-	return layout.Render(allContext...)
+	return layout.FRender(out, allContext...)
 }
 
 // ParseString compiles a mustache template string. The resulting output can

--- a/mustache.go
+++ b/mustache.go
@@ -581,16 +581,22 @@ func (tmpl *Template) renderTemplate(contextChain []interface{}, buf io.Writer) 
 	return nil
 }
 
-// Render uses the given data source - generally a map or struct - to render
-// the compiled template and return the output.
-func (tmpl *Template) Render(context ...interface{}) (string, error) {
-	var buf bytes.Buffer
+// FRender uses the given data source - generally a map or struct - to
+// render the compiled template to an io.Writer.
+func (tmpl *Template) FRender(out io.Writer, context ...interface{}) error {
 	var contextChain []interface{}
 	for _, c := range context {
 		val := reflect.ValueOf(c)
 		contextChain = append(contextChain, val)
 	}
-	err := tmpl.renderTemplate(contextChain, &buf)
+	return tmpl.renderTemplate(contextChain, out)
+}
+
+// Render uses the given data source - generally a map or struct - to render
+// the compiled template and return the output.
+func (tmpl *Template) Render(context ...interface{}) (string, error) {
+	var buf bytes.Buffer
+	err := tmpl.FRender(&buf, context...)
 	return buf.String(), err
 }
 

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -1,6 +1,7 @@
 package mustache
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path"
@@ -239,6 +240,24 @@ func TestFile(t *testing.T) {
 		t.Error(err)
 	} else if output != expected {
 		t.Errorf("testfile expected %q got %q", expected, output)
+	}
+}
+
+func TestFRender(t *testing.T) {
+	filename := path.Join(path.Join(os.Getenv("PWD"), "tests"), "test1.mustache")
+	expected := "hello world"
+	tmpl, err := ParseFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	err = tmpl.FRender(&buf, map[string]string{"name": "world"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+	if output != expected {
+		t.Fatalf("testfile expected %q got %q", expected, output)
 	}
 }
 

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -375,6 +375,28 @@ func TestLayout(t *testing.T) {
 	}
 }
 
+func TestLayoutToWriter(t *testing.T) {
+	for _, test := range layoutTests {
+		tmpl, err := ParseString(test.tmpl)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		layoutTmpl, err := ParseString(test.layout)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		var buf bytes.Buffer
+		err = tmpl.FRenderInLayout(&buf, layoutTmpl, test.context)
+		if err != nil {
+			t.Error(err)
+		} else if buf.String() != test.expected {
+			t.Errorf("%q expected %q got %q", test.tmpl, test.expected, buf.String())
+		}
+	}
+}
+
 type Person struct {
 	FirstName string
 	LastName  string


### PR DESCRIPTION
This adds an extra function `FRender` that accepts an io.Writer as its
first argument in order to support direct writing to some sink. The name
has been chosen for consistency with the fmt package.

A few potential concerns:

* Is this the most idiomatic way to support this?
* If it is useful, should this also be introduced to `RenderInLayout` for consistency?
* The test style isn't quite consistent with the surrounding tests. Would it be better
  to drop the use of `t.Fatal` in favour of consistency?