### PR TITLE
Indent partials

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -87,8 +87,9 @@ type sectionElement struct {
 }
 
 type partialElement struct {
-	name string
-	prov PartialProvider
+	name   string
+	indent string
+	prov   PartialProvider
 }
 
 // Template represents a compilde mustache template
@@ -310,10 +311,11 @@ func (tmpl *Template) readTag(mayStandalone bool) (*tagReadingResult, error) {
 	}, nil
 }
 
-func (tmpl *Template) parsePartial(name string) (*partialElement, error) {
+func (tmpl *Template) parsePartial(name, indent string) (*partialElement, error) {
 	return &partialElement{
-		name: name,
-		prov: tmpl.partial,
+		name:   name,
+		indent: indent,
+		prov:   tmpl.partial,
 	}, nil
 }
 
@@ -362,7 +364,7 @@ func (tmpl *Template) parseSection(section *sectionElement) error {
 			return nil
 		case '>':
 			name := strings.TrimSpace(tag[1:])
-			partial, err := tmpl.parsePartial(name)
+			partial, err := tmpl.parsePartial(name, textResult.padding)
 			if err != nil {
 				return err
 			}
@@ -430,7 +432,7 @@ func (tmpl *Template) parse() error {
 			return parseError{tmpl.curline, "unmatched close tag"}
 		case '>':
 			name := strings.TrimSpace(tag[1:])
-			partial, err := tmpl.parsePartial(name)
+			partial, err := tmpl.parsePartial(name, textResult.padding)
 			if err != nil {
 				return err
 			}
@@ -628,7 +630,7 @@ func renderElement(element interface{}, contextChain []interface{}, buf io.Write
 			return err
 		}
 	case *partialElement:
-		partial, err := getPartials(elem.prov, elem.name)
+		partial, err := getPartials(elem.prov, elem.name, elem.indent)
 		if err != nil {
 			return err
 		}

--- a/mustache.go
+++ b/mustache.go
@@ -628,7 +628,7 @@ func renderElement(element interface{}, contextChain []interface{}, buf io.Write
 			return err
 		}
 	case *partialElement:
-		partial, err := elem.prov.Get(elem.name)
+		partial, err := getPartials(elem.prov, elem.name)
 		if err != nil {
 			return err
 		}

--- a/partials.go
+++ b/partials.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"regexp"
 )
 
 // PartialProvider comprises the behaviors required of a struct to be able to provide partials to the mustache rendering
@@ -85,11 +86,15 @@ func (sp *StaticProvider) Get(name string) (string, error) {
 
 var _ PartialProvider = (*StaticProvider)(nil)
 
-func getPartials(partials PartialProvider, name string) (*Template, error) {
+func getPartials(partials PartialProvider, name, indent string) (*Template, error) {
 	data, err := partials.Get(name)
 	if err != nil {
 		return nil, err
 	}
+
+	// indent non empty lines
+	r := regexp.MustCompile(`(?m:^(.+)$)`)
+	data = r.ReplaceAllString(data, indent+"$1")
 
 	return ParseStringPartials(data, partials)
 }

--- a/partials.go
+++ b/partials.go
@@ -1,6 +1,7 @@
 package mustache
 
 import (
+	"io/ioutil"
 	"os"
 	"path"
 )
@@ -11,7 +12,7 @@ type PartialProvider interface {
 	// Get accepts the name of a partial and returns the parsed partial, if it could be found; a valid but empty
 	// template, if it could not be found; or nil and error if an error occurred (other than an inability to find
 	// the partial).
-	Get(name string) (*Template, error)
+	Get(name string) (string, error)
 }
 
 // FileProvider implements the PartialProvider interface by providing partials drawn from a filesystem. When a partial
@@ -23,7 +24,7 @@ type FileProvider struct {
 	Extensions []string
 }
 
-func (fp *FileProvider) Get(name string) (*Template, error) {
+func (fp *FileProvider) Get(name string) (string, error) {
 	var filename string
 
 	var paths []string
@@ -53,10 +54,15 @@ func (fp *FileProvider) Get(name string) (*Template, error) {
 	}
 
 	if filename == "" {
-		return ParseString("")
+		return "", nil
 	}
 
-	return ParseFile(filename)
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
 }
 
 var _ PartialProvider = (*FileProvider)(nil)
@@ -67,14 +73,23 @@ type StaticProvider struct {
 	Partials map[string]string
 }
 
-func (sp *StaticProvider) Get(name string) (*Template, error) {
+func (sp *StaticProvider) Get(name string) (string, error) {
 	if sp.Partials != nil {
 		if data, ok := sp.Partials[name]; ok {
-			return ParseStringPartials(data, sp)
+			return data, nil
 		}
 	}
 
-	return ParseString("")
+	return "", nil
 }
 
 var _ PartialProvider = (*StaticProvider)(nil)
+
+func getPartials(partials PartialProvider, name string) (*Template, error) {
+	data, err := partials.Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseStringPartials(data, partials)
+}

--- a/spec_test.go
+++ b/spec_test.go
@@ -102,9 +102,9 @@ var enabledTests = map[string]map[string]bool{
 		"Surrounding Whitespace":           true,
 		"Inline Indentation":               true,
 		"Standalone Line Endings":          true,
-		"Standalone Without Previous Line": false,
-		"Standalone Without Newline":       false,
-		"Standalone Indentation":           false,
+		"Standalone Without Previous Line": true,
+		"Standalone Without Newline":       true,
+		"Standalone Indentation":           true,
 		"Padding Whitespace":               true,
 	},
 	"sections.json": map[string]bool{


### PR DESCRIPTION
Support partial template indentation.

This PR breaks `PartialProvider.Get` interface.
