### PR TITLE
correct installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Also check out some [example mustache files](http://github.com/defunkt/mustache/
 
 ## Installation
 
-To install mustache.go, simply run `go get github.com/cbroglie/mustache`. To use it in a program, use `import "github.com/cbroglie/mustache"`
+To install mustache.go, simply run `go install github.com/cbroglie/mustache/...`. To use it in a program, use `import "github.com/cbroglie/mustache"`
 
 ## Usage
 


### PR DESCRIPTION
Since the `main.go` isn't at the root of the repository, you need to add the ellipsis at the end of the package.