### PR TITLE
add custom delimiter

### DIFF
--- a/custom/custom_test.go
+++ b/custom/custom_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cbroglie/mustache"
+)
+
+func TestCustomDelimiter(t *testing.T) {
+	var (
+		in  = "hello <% name %>"
+		out = "hello world"
+	)
+	mustache.TagStart = "<%"
+	mustache.TagEnd = "%>"
+	s, err := mustache.ParseString(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vars := map[string]interface{}{
+		"name": "world",
+	}
+	result, err := s.Render(vars)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != out {
+		t.Errorf("wont %s, but got %s", out, result)
+	}
+}

--- a/mustache.go
+++ b/mustache.go
@@ -18,6 +18,10 @@ var (
 	// is true (the default), an empty string is emitted. If it is false, an error
 	// is generated instead.
 	AllowMissingVariables = true
+	// TagStart is start delimiter.
+	TagStart = "{{"
+	// TagEnd is end delimiter.
+	TagEnd = "}}"
 )
 
 // A TagType represents the specific type of mustache tag that a Tag
@@ -733,7 +737,7 @@ func ParseStringPartials(data string, partials PartialProvider) (*Template, erro
 // to efficiently render the template multiple times with different data
 // sources.
 func ParseStringPartialsRaw(data string, partials PartialProvider, forceRaw bool) (*Template, error) {
-	tmpl := Template{data, "{{", "}}", 0, 1, []interface{}{}, forceRaw, partials}
+	tmpl := Template{data, TagStart, TagEnd, 0, 1, []interface{}{}, forceRaw, partials}
 	err := tmpl.parse()
 
 	if err != nil {
@@ -773,7 +777,7 @@ func ParseFilePartialsRaw(filename string, forceRaw bool, partials PartialProvid
 		return nil, err
 	}
 
-	tmpl := Template{string(data), "{{", "}}", 0, 1, []interface{}{}, forceRaw, partials}
+	tmpl := Template{string(data), TagStart, TagEnd, 0, 1, []interface{}{}, forceRaw, partials}
 	err = tmpl.parse()
 
 	if err != nil {


### PR DESCRIPTION
Set Delimiter
Set Delimiter tags start with an equal sign and change the tag delimiters from {{ and }} to custom strings.

Consider the following contrived example:

* {{default_tags}}
{{=<% %>=}}
* <% erb_style_tags %>
<%={{ }}=%>
* {{ default_tags_again }}
Here we have a list with three items. The first item uses the default tag style, the second uses erb style as defined by the Set Delimiter tag, and the third returns to the default style after yet another Set Delimiter declaration.

According to ctemplates, this "is useful for languages like TeX, where double-braces may occur in the text and are awkward to use for markup."

Custom delimiters may not contain whitespace or the equals sign.