### PR TITLE
Implement output modes for JSON and plain text generation

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -370,8 +370,8 @@ func (tmpl *Template) parseSection(section *sectionElement) error {
 			}
 			section.elems = append(section.elems, partial)
 		case '=':
-			if tag[len(tag)-1] != '=' {
-				return parseError{tmpl.curline, "Invalid meta tag"}
+			if len(tag) < 2 || tag[len(tag)-1] != '=' {
+				return parseError{tmpl.curline, "invalid meta tag"}
 			}
 			tag = strings.TrimSpace(tag[1 : len(tag)-1])
 			newtags := strings.SplitN(tag, " ", 2)

--- a/mustache.go
+++ b/mustache.go
@@ -92,7 +92,7 @@ type partialElement struct {
 	prov   PartialProvider
 }
 
-// Template represents a compilde mustache template
+// Template represents a compiled mustache template
 type Template struct {
 	data     string
 	otag     string
@@ -231,7 +231,7 @@ func (tmpl *Template) readText() (*textReadingResult, error) {
 		}
 	}
 
-	mayStandalone := (i == 0 || tmpl.data[i-1] == '\n')
+	mayStandalone := i == 0 || tmpl.data[i-1] == '\n'
 
 	if mayStandalone {
 		return &textReadingResult{
@@ -528,7 +528,7 @@ Outer:
 	if allowMissing {
 		return reflect.Value{}, nil
 	}
-	return reflect.Value{}, fmt.Errorf("Missing variable %q", name)
+	return reflect.Value{}, fmt.Errorf("missing variable %q", name)
 }
 
 func isEmpty(v reflect.Value) bool {
@@ -571,7 +571,7 @@ func renderSection(section *sectionElement, contextChain []interface{}, buf io.W
 		return err
 	}
 	var context = contextChain[len(contextChain)-1].(reflect.Value)
-	var contexts = []interface{}{}
+	var contexts []interface{}
 	// if the value is nil, check if it's an inverted section
 	isEmpty := isEmpty(value)
 	if isEmpty && !section.inverted || !isEmpty && section.inverted {
@@ -717,7 +717,7 @@ func ParseString(data string) (*Template, error) {
 func ParseStringRaw(data string, forceRaw bool) (*Template, error) {
 	cwd := os.Getenv("CWD")
 	partials := &FileProvider{
-		Paths: []string{cwd, " "},
+		Paths: []string{cwd},
 	}
 
 	return ParseStringPartialsRaw(data, partials, forceRaw)
@@ -752,7 +752,7 @@ func ParseStringPartialsRaw(data string, partials PartialProvider, forceRaw bool
 func ParseFile(filename string) (*Template, error) {
 	dirname, _ := path.Split(filename)
 	partials := &FileProvider{
-		Paths: []string{dirname, " "},
+		Paths: []string{dirname},
 	}
 
 	return ParseFilePartials(filename, partials)

--- a/mustache.go
+++ b/mustache.go
@@ -715,7 +715,10 @@ func ParseString(data string) (*Template, error) {
 // be used to efficiently render the template multiple times with different data
 // sources.
 func ParseStringRaw(data string, forceRaw bool) (*Template, error) {
-	cwd := os.Getenv("CWD")
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
 	partials := &FileProvider{
 		Paths: []string{cwd},
 	}

--- a/mustache_fuzz.go
+++ b/mustache_fuzz.go
@@ -1,0 +1,19 @@
+// +build gofuzz
+
+package mustache
+
+// Fuzzing code for use with github.com/dvyukov/go-fuzz
+//
+// To use, in the main project directory do:
+//
+//   go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+//   go-fuzz-build
+//   go-fuzz
+
+func Fuzz(data []byte) int {
+	_, err := ParseString(string(data))
+	if err == nil {
+		return 1
+	}
+	return 0
+}

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -239,7 +239,7 @@ func TestMissing(t *testing.T) {
 		output, err := Render(test.tmpl, test.context)
 		if err == nil {
 			t.Errorf("%q expected missing variable error but got %q", test.tmpl, output)
-		} else if !strings.Contains(err.Error(), "Missing variable") {
+		} else if !strings.Contains(err.Error(), "missing variable") {
 			t.Errorf("%q expected missing variable error but got %q", test.tmpl, err.Error())
 		}
 	}
@@ -298,6 +298,20 @@ func TestPartial(t *testing.T) {
 		},
 	}
 	compareTags(t, tmpl.Tags(), expectedTags)
+}
+
+func TestPartialSafety(t *testing.T) {
+	tmpl, err := ParseString("{{>../unsafe}}")
+	if err != nil {
+		t.Error(err)
+	}
+	txt, err := tmpl.Render(nil)
+	if err == nil {
+		t.Errorf("expected error for unsafe partial")
+	}
+	if txt != "" {
+		t.Errorf("expected unsafe partial to fail")
+	}
 }
 
 /*

--- a/spec_test.go
+++ b/spec_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var enabledTests = map[string]map[string]bool{
-	"comments.json": map[string]bool{
+	"comments.json": {
 		"Inline":                           true,
 		"Multiline":                        true,
 		"Standalone":                       true,
@@ -22,8 +22,8 @@ var enabledTests = map[string]map[string]bool{
 		"Indented Multiline Standalone":    true,
 		"Indented Inline":                  true,
 		"Surrounding Whitespace":           true,
-	},
-	"delimiters.json": map[string]bool{
+		},
+	"delimiters.json": {
 		"Pair Behavior":                    true,
 		"Special Characters":               true,
 		"Sections":                         true,
@@ -38,8 +38,8 @@ var enabledTests = map[string]map[string]bool{
 		"Standalone Line Endings":          true,
 		"Standalone Without Previous Line": true,
 		"Standalone Without Newline":       true,
-	},
-	"interpolation.json": map[string]bool{
+		},
+	"interpolation.json": {
 		"No Interpolation":    true,
 		"Basic Interpolation": true,
 		// disabled b/c Go uses "&#34;" in place of "&quot;"
@@ -72,8 +72,8 @@ var enabledTests = map[string]map[string]bool{
 		"Interpolation With Padding":                   true,
 		"Triple Mustache With Padding":                 true,
 		"Ampersand With Padding":                       true,
-	},
-	"inverted.json": map[string]bool{
+		},
+	"inverted.json": {
 		"Falsey":                           true,
 		"Truthy":                           true,
 		"Context":                          true,
@@ -95,8 +95,8 @@ var enabledTests = map[string]map[string]bool{
 		"Standalone Line Endings":          true,
 		"Standalone Without Previous Line": true,
 		"Standalone Without Newline":       true,
-	},
-	"partials.json": map[string]bool{
+		},
+	"partials.json": {
 		"Basic Behavior":                   true,
 		"Failed Lookup":                    true,
 		"Context":                          true,
@@ -108,8 +108,8 @@ var enabledTests = map[string]map[string]bool{
 		"Standalone Without Newline":       true,
 		"Standalone Indentation":           true,
 		"Padding Whitespace":               true,
-	},
-	"sections.json": map[string]bool{
+		},
+	"sections.json": {
 		"Truthy":                           true,
 		"Falsey":                           true,
 		"Context":                          true,
@@ -136,7 +136,7 @@ var enabledTests = map[string]map[string]bool{
 		"Standalone Without Previous Line": true,
 		"Standalone Without Newline":       true,
 		"Padding":                          true,
-	},
+		},
 	"~lambdas.json": nil, // not implemented
 }
 


### PR DESCRIPTION
This feature branch adds a way to use Mustache templates for templating JSON and/or plain text.

Use cases:
 - Generating Slack messages from user data.
 - Generating e-mail messages and subject lines.

The default behavior remains as before, for safety. Calling code must be changed to explicitly override the escape mode selection.