### PR TITLE
Fix building context stack for inner elements of sections

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -570,7 +570,7 @@ func renderSection(section *sectionElement, contextChain []interface{}, buf io.W
 	if err != nil {
 		return err
 	}
-	var context = contextChain[len(contextChain)-1].(reflect.Value)
+	var context = contextChain[0].(reflect.Value)
 	var contexts = []interface{}{}
 	// if the value is nil, check if it's an inverted section
 	isEmpty := isEmpty(value)

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -179,6 +179,24 @@ var tests = []Test{
 		"categories": {&Category{"a", "b"}},
 	}, "a - b", nil},
 
+	{`{{#section}}{{#bool}}{{x}}{{/bool}}{{/section}}`,
+		map[string]interface{}{
+			"x": "broken",
+			"section": []map[string]interface{}{
+				{"x": "working", "bool": true},
+				{"x": "nope", "bool": false},
+			},
+		}, "working", nil},
+
+	{`{{#section}}{{^bool}}{{x}}{{/bool}}{{/section}}`,
+		map[string]interface{}{
+			"x": "broken",
+			"section": []map[string]interface{}{
+				{"x": "working", "bool": false},
+				{"x": "nope", "bool": true},
+			},
+		}, "working", nil},
+
 	//dotted names(dot notation)
 	{`"{{person.name}}" == "{{#person}}{{name}}{{/person}}"`, map[string]interface{}{"person": map[string]string{"name": "Joe"}}, `"Joe" == "Joe"`, nil},
 	{`"{{{person.name}}}" == "{{#person}}{{{name}}}{{/person}}"`, map[string]interface{}{"person": map[string]string{"name": "Joe"}}, `"Joe" == "Joe"`, nil},


### PR DESCRIPTION
This fixes https://github.com/cbroglie/mustache/issues/53. When building the context stack for elements inside sections now, we're not starting with the outermost context anymore, but the innermost.

Two tests are added which test for the correct behavior here, all other tests still pass.