### PR TITLE
Fix rendering non-false value sections

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -590,7 +590,10 @@ func renderSection(section *sectionElement, contextChain []interface{}, buf io.W
 		case reflect.Map, reflect.Struct:
 			contexts = append(contexts, value)
 		default:
-			contexts = append(contexts, context)
+			// Spec: Non-false sections have their value at the top of context,
+			// accessible as {{.}} or through the parent context. This gives
+			// a simple way to display content conditionally if a variable exists.
+			contexts = append(contexts, value)
 		}
 	} else if section.inverted {
 		contexts = append(contexts, context)

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -140,6 +140,9 @@ var tests = []Test{
 	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": []interface{}{0}}, "Hi 0", nil},
 	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": [1]interface{}{0}}, "Hi 0", nil},
 
+	// non-false section have their value at the top of the context
+	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": "Rob"}, "Hi Rob", nil},
+
 	//section does not exist
 	{`{{#has}}{{/has}}`, &User{"Mike", 1}, "", nil},
 

--- a/spec_test.go
+++ b/spec_test.go
@@ -20,11 +20,6 @@ var disabledTests = map[string]map[string]struct{}{
 		"Ampersand Null Interpolation":       struct{}{},
 		"Implicit Iterators - HTML Escaping": struct{}{},
 	},
-	// To be fixed by https://github.com/cbroglie/mustache/pull/55
-	"sections.json": {
-		"Variable test":          struct{}{},
-		"Deeply Nested Contexts": struct{}{},
-	},
 	"~lambdas.json":     {}, // not implemented
 	"~inheritance.json": {}, // not implemented
 }


### PR DESCRIPTION
This fixes rendering sections not backed by a slice, map or struct, but not false either.

According to the spec, this should work, so I fixed it and added a small test.

Sidenote: I think this should have been caught in `spec_test.go`, but for some reason this test is not part of the tested `.json` files (it _is_ part of the `.yaml` files in mustache/spec, though).