### PR TITLE
mustache: expose missing variable control

### DIFF
--- a/cmd/mustache/main.go
+++ b/cmd/mustache/main.go
@@ -32,6 +32,7 @@ var overrideFile string
 func main() {
 	rootCmd.Flags().StringVar(&layoutFile, "layout", "", "location of layout file")
 	rootCmd.Flags().StringVar(&overrideFile, "override", "", "location of data.yml override yml")
+	rootCmd.Flags().BoolVar(&mustache.AllowMissingVariables, "allow-missing-variables", true, "allow missing variables")
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
Exposes a missing variable control to the command-line to allow render
to fail on missing variables `--allow-missing-variables=false`.