### PR TITLE
render: allow use of conditional iteration

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -508,6 +508,16 @@ Outer:
 				v = av.Elem()
 			case reflect.Interface:
 				v = av.Elem()
+			case reflect.Array, reflect.Slice:
+				idx, err := strconv.Atoi(name)
+				if err != nil {
+					return reflect.Value{}, fmt.Errorf("non-integer slice index %q", name)
+				}
+				ret := av.Index(idx)
+				if ret.IsValid() {
+					return ret, nil
+				}
+				continue Outer
 			case reflect.Struct:
 				ret := av.FieldByName(name)
 				if ret.IsValid() {
@@ -541,7 +551,7 @@ func isEmpty(v reflect.Value) bool {
 		return true
 	}
 	switch val := valueInd; val.Kind() {
-	case reflect.Array, reflect.Slice:
+	case reflect.Array, reflect.Slice, reflect.Map:
 		return val.Len() == 0
 	case reflect.String:
 		return len(strings.TrimSpace(val.String())) == 0

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -151,6 +151,13 @@ var tests = []Test{
 	{`"{{#list}}({{.}}){{/list}}"`, map[string]interface{}{"list": []int{1, 2, 3, 4, 5}}, "\"(1)(2)(3)(4)(5)\"", nil},
 	{`"{{#list}}({{.}}){{/list}}"`, map[string]interface{}{"list": []float64{1.10, 2.20, 3.30, 4.40, 5.50}}, "\"(1.1)(2.2)(3.3)(4.4)(5.5)\"", nil},
 
+	// conditional implicit iterator tests
+	{`"{{#list.0}}items{{/list.0}}"`, map[string]interface{}{"list": []string{"a", "b", "c"}}, "\"items\"", nil},
+	{`"{{^list.0}}empty{{/list.0}}"`, map[string]interface{}{}, "\"empty\"", nil},
+	{`"{{#list.0}}{{#list}}({{.}}){{/list}}{{/list.0}}"`, map[string]interface{}{"list": []string{"a", "b", "c", "d", "e"}}, "\"(a)(b)(c)(d)(e)\"", nil},
+	{`"{{#list.0}}{{#list}}({{.}}){{/list}}{{/list.0}}"`, map[string]interface{}{"list": []int{1, 2, 3, 4, 5}}, "\"(1)(2)(3)(4)(5)\"", nil},
+	{`"{{#list.0}}{{#list}}({{.}}){{/list}}{{/list.0}}"`, map[string]interface{}{"list": []float64{1.10, 2.20, 3.30, 4.40, 5.50}}, "\"(1.1)(2.2)(3.3)(4.4)(5.5)\"", nil},
+
 	//inverted section tests
 	{`{{a}}{{^b}}b{{/b}}{{c}}`, map[string]interface{}{"a": "a", "b": false, "c": "c"}, "abc", nil},
 	{`{{^a}}b{{/a}}`, map[string]interface{}{"a": false}, "b", nil},
@@ -356,6 +363,8 @@ var malformed = []Test{
 	{`{{`, nil, "", fmt.Errorf("line 1: unmatched open tag")},
 	//invalid syntax - https://github.com/hoisie/mustache/issues/10
 	{`{{#a}}{{#b}}{{/a}}{{/b}}}`, map[string]interface{}{}, "", fmt.Errorf("line 1: interleaved closing tag: a")},
+	// non-integer index
+	{`"{{#list.a}}{{#list}}({{.}}){{/list}}{{/list.a}}"`, map[string]interface{}{"list": []string{"a", "b", "c", "d", "e"}}, "", fmt.Errorf("non-integer slice index \"a\"")},
 }
 
 func TestMalformed(t *testing.T) {


### PR DESCRIPTION
A technique used for languages that do not support a lenght property is
to allow conditional checks on sub-elements of the array.

```
{{#users.0}}
...
{{/users.0}}
{{^users.0}}
...
{{/users.0}}
```