### PR TITLE
fix: README manual page broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ This library is an implementation of the Mustache template language in Go.
 
 ## Documentation
 
-For more information about mustache, check out the [mustache project page](http://github.com/defunkt/mustache) or the [mustache manual](http://mustache.github.com/mustache.5.html).
+For more information about mustache, check out the [mustache project page](https://github.com/mustache/mustache) or the [mustache manual](https://mustache.github.io/mustache.5.html).
 
-Also check out some [example mustache files](http://github.com/defunkt/mustache/tree/master/examples/)
+Also check out some [example mustache files](http://github.com/mustache/mustache/tree/master/examples/)
 
 ----
 


### PR DESCRIPTION
The manual page at mustache/mustache moved to GitHub pages