### PR TITLE
Support for releasing ARM64 binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,3 +10,4 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64


### PR DESCRIPTION
This PR is to use mustache easily on ARM64 machines.

related to #74 

Tests are passed on darwin/arm64, 

```
$ go version
go version go1.18.2 darwin/arm64
$ make test
go test -race -coverprofile=coverage.txt -covermode=atomic ./...
ok  	github.com/cbroglie/mustache	0.140s	coverage: 88.6% of statements
?   	github.com/cbroglie/mustache/cmd/mustache	[no test files]
```

and linux/arm64.

```
$ go version
go version go1.18.2 linux/arm64
$ make test
go test -race -coverprofile=coverage.txt -covermode=atomic ./...
ok  	github.com/cbroglie/mustache	0.085s	coverage: 88.6% of statements
?   	github.com/cbroglie/mustache/cmd/mustache	[no test files]
```