### PR TITLE
Fix panic in Set Delimiter parsing.

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -374,15 +374,7 @@ func (tmpl *Template) parseSection(section *sectionElement) error {
 			}
 			section.elems = append(section.elems, partial)
 		case '=':
-			if tag[len(tag)-1] != '=' {
-				return newError(tmpl.curline, ErrInvalidMetaTag)
-			}
-			tag = strings.TrimSpace(tag[1 : len(tag)-1])
-			newtags := strings.SplitN(tag, " ", 2)
-			if len(newtags) == 2 {
-				tmpl.otag = newtags[0]
-				tmpl.ctag = newtags[1]
-			}
+			tmpl.parseCustomDelimiter(tag)
 		case '{':
 			if tag[len(tag)-1] == '}' {
 				//use a raw tag
@@ -449,11 +441,7 @@ func (tmpl *Template) parse() error {
 				return newError(tmpl.curline, ErrInvalidMetaTag)
 			}
 			tag = strings.TrimSpace(tag[1 : len(tag)-1])
-			newtags := strings.SplitN(tag, " ", 2)
-			if len(newtags) == 2 {
-				tmpl.otag = newtags[0]
-				tmpl.ctag = newtags[1]
-			}
+			tmpl.parseCustomDelimiter(tag)
 		case '{':
 			//use a raw tag
 			if tag[len(tag)-1] == '}' {
@@ -466,6 +454,21 @@ func (tmpl *Template) parse() error {
 		default:
 			tmpl.elems = append(tmpl.elems, &varElement{tag, tmpl.forceRaw})
 		}
+	}
+}
+
+func (tmpl *Template) parseCustomDelimiter(tag string) {
+	if len(tag) < 3 || tag[len(tag)-1] != '=' {
+		tmpl.elems = append(tmpl.elems, &varElement{tag, tmpl.forceRaw})
+		return
+	}
+	trimmedtag := strings.TrimSpace(tag[1 : len(tag)-1])
+	newtags := strings.SplitN(trimmedtag, " ", 2)
+	if len(newtags) == 2 {
+		tmpl.otag = newtags[0]
+		tmpl.ctag = newtags[1]
+	} else {
+		tmpl.elems = append(tmpl.elems, &varElement{tag, tmpl.forceRaw})
 	}
 }
 

--- a/mustache.go
+++ b/mustache.go
@@ -437,10 +437,6 @@ func (tmpl *Template) parse() error {
 			}
 			tmpl.elems = append(tmpl.elems, partial)
 		case '=':
-			if tag[len(tag)-1] != '=' {
-				return newError(tmpl.curline, ErrInvalidMetaTag)
-			}
-			tag = strings.TrimSpace(tag[1 : len(tag)-1])
 			tmpl.parseCustomDelimiter(tag)
 		case '{':
 			//use a raw tag

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -94,6 +94,12 @@ var tests = []Test{
 	{`hello {{! comment }}world`, map[string]string{}, "hello world", nil},
 	{`{{ a }}{{=<% %>=}}<%b %><%={{ }}=%>{{ c }}`, map[string]string{"a": "a", "b": "b", "c": "c"}, "abc", nil},
 	{`{{ a }}{{= <% %> =}}<%b %><%= {{ }}=%>{{c}}`, map[string]string{"a": "a", "b": "b", "c": "c"}, "abc", nil},
+	// variables that look like malformed custom delimiter tags
+	{`{{=}}`, map[string]string{"=": "a"}, "a", nil},
+	{`{{= %}}`, map[string]string{"= %": "a"}, "a", nil},
+	{`{{==}}`, map[string]string{"==": "a"}, "a", nil},
+	{`{{= =}}`, map[string]string{"= =": "a"}, "a", nil},
+	{`{{#A}}{{=}}{{/A}}`, map[string]string{"=": "a"}, "a", nil},
 
 	//section tests
 	{`{{#A}}{{B}}{{/A}}`, Data{true, "hello"}, "hello", nil},


### PR DESCRIPTION
Mustache supports Set Delimter tags, of the form `{{=<open tag> <close tag>=}}`, which is used to change the delimiters from `{{` and `}}`. Prior to this commit, if there was a sequence that looked like the start of a Set Delimiter tag, but there was not a complete Set Delimiter tag, the library could panic.

This commit:
    * factors out the Set Delimiter tag parsing into a new function, 'parseCustomDelimiter()'
    * adds checks to make sure an incomplete tag doesn't cause an access off the end of a slice
    * treats an incomplete Set Delimiter (like `{{=}}`) as a normaal tag

This behaviour matches the mustache playground at
https://jgonggrijp.gitlab.io/wontache/playground.html. I tried to match the behaviour of the Ruby implementation, but it seems to be inconsistent in this case.