### PR TITLE
add custom lookup support

### DIFF
--- a/mustache_test.go
+++ b/mustache_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -95,7 +96,7 @@ var tests = []Test{
 	{`{{ a }}{{=<% %>=}}<%b %><%={{ }}=%>{{ c }}`, map[string]string{"a": "a", "b": "b", "c": "c"}, "abc", nil},
 	{`{{ a }}{{= <% %> =}}<%b %><%= {{ }}=%>{{c}}`, map[string]string{"a": "a", "b": "b", "c": "c"}, "abc", nil},
 
-	//section tests
+	// section tests
 	{`{{#A}}{{B}}{{/A}}`, Data{true, "hello"}, "hello", nil},
 	{`{{#A}}{{{B}}}{{/A}}`, Data{true, "5 > 2"}, "5 > 2", nil},
 	{`{{#A}}{{B}}{{/A}}`, Data{true, "5 > 2"}, "5 &gt; 2", nil},
@@ -127,7 +128,7 @@ var tests = []Test{
 	{"{{#users}}\n{{Name}}\n{{/users}}", map[string]interface{}{"users": makeVector(2)}, "Mike\nMike\n", nil},
 	{"{{#users}}\r\n{{Name}}\r\n{{/users}}", map[string]interface{}{"users": makeVector(2)}, "Mike\r\nMike\r\n", nil},
 
-	//falsy: golang zero values
+	// falsy: golang zero values
 	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": nil}, "", nil},
 	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": false}, "", nil},
 	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": 0}, "", nil},
@@ -136,7 +137,7 @@ var tests = []Test{
 	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": Data{}}, "", nil},
 	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": []interface{}{}}, "", nil},
 	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": [0]interface{}{}}, "", nil},
-	//falsy: special cases we disagree with golang
+	// falsy: special cases we disagree with golang
 	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": "\t"}, "", nil},
 	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": []interface{}{0}}, "Hi 0", nil},
 	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": [1]interface{}{0}}, "Hi 0", nil},
@@ -144,7 +145,7 @@ var tests = []Test{
 	// non-false section have their value at the top of the context
 	{"{{#a}}Hi {{.}}{{/a}}", map[string]interface{}{"a": "Rob"}, "Hi Rob", nil},
 
-	//section does not exist
+	// section does not exist
 	{`{{#has}}{{/has}}`, &User{"Mike", 1}, "", nil},
 
 	// implicit iterator tests
@@ -152,7 +153,7 @@ var tests = []Test{
 	{`"{{#list}}({{.}}){{/list}}"`, map[string]interface{}{"list": []int{1, 2, 3, 4, 5}}, "\"(1)(2)(3)(4)(5)\"", nil},
 	{`"{{#list}}({{.}}){{/list}}"`, map[string]interface{}{"list": []float64{1.10, 2.20, 3.30, 4.40, 5.50}}, "\"(1.1)(2.2)(3.3)(4.4)(5.5)\"", nil},
 
-	//inverted section tests
+	// inverted section tests
 	{`{{a}}{{^b}}b{{/b}}{{c}}`, map[string]interface{}{"a": "a", "b": false, "c": "c"}, "abc", nil},
 	{`{{^a}}b{{/a}}`, map[string]interface{}{"a": false}, "b", nil},
 	{`{{^a}}b{{/a}}`, map[string]interface{}{"a": true}, "", nil},
@@ -160,7 +161,7 @@ var tests = []Test{
 	{`{{^a}}b{{/a}}`, map[string]interface{}{"a": []string{}}, "b", nil},
 	{`{{a}}{{^b}}b{{/b}}{{c}}`, map[string]string{"a": "a", "c": "c"}, "abc", nil},
 
-	//function tests
+	// function tests
 	{`{{#users}}{{Func1}}{{/users}}`, map[string]interface{}{"users": []User{{"Mike", 1}}}, "Mike", nil},
 	{`{{#users}}{{Func1}}{{/users}}`, map[string]interface{}{"users": []*User{{"Mike", 1}}}, "Mike", nil},
 	{`{{#users}}{{Func2}}{{/users}}`, map[string]interface{}{"users": []*User{{"Mike", 1}}}, "Mike", nil},
@@ -174,7 +175,7 @@ var tests = []Test{
 	{`{{#user}}{{#Func5}}{{#Allow}}abcd{{/Allow}}{{/Func5}}{{/user}}`, map[string]interface{}{"user": &User{"Mike", 1}}, "abcd", nil},
 	{`{{#user}}{{#Func6}}{{#Allow}}abcd{{/Allow}}{{/Func6}}{{/user}}`, map[string]interface{}{"user": &User{"Mike", 1}}, "abcd", nil},
 
-	//context chaining
+	// context chaining
 	{`hello {{#section}}{{name}}{{/section}}`, map[string]interface{}{"section": map[string]string{"name": "world"}}, "hello world", nil},
 	{`hello {{#section}}{{name}}{{/section}}`, map[string]interface{}{"name": "bob", "section": map[string]string{"name": "world"}}, "hello world", nil},
 	{`hello {{#bool}}{{#section}}{{name}}{{/section}}{{/bool}}`, map[string]interface{}{"bool": true, "section": map[string]string{"name": "world"}}, "hello world", nil},
@@ -201,7 +202,7 @@ var tests = []Test{
 			},
 		}, "working", nil},
 
-	//dotted names(dot notation)
+	// dotted names(dot notation)
 	{`"{{person.name}}" == "{{#person}}{{name}}{{/person}}"`, map[string]interface{}{"person": map[string]string{"name": "Joe"}}, `"Joe" == "Joe"`, nil},
 	{`"{{{person.name}}}" == "{{#person}}{{{name}}}{{/person}}"`, map[string]interface{}{"person": map[string]string{"name": "Joe"}}, `"Joe" == "Joe"`, nil},
 	{`"{{a.b.c.d.e.name}}" == "Phil"`, map[string]interface{}{"a": map[string]interface{}{"b": map[string]interface{}{"c": map[string]interface{}{"d": map[string]interface{}{"e": map[string]string{"name": "Phil"}}}}}}, `"Phil" == "Phil"`, nil},
@@ -233,11 +234,11 @@ func TestBasic(t *testing.T) {
 }
 
 var missing = []Test{
-	//does not exist
+	// does not exist
 	{`{{dne}}`, map[string]string{"name": "world"}, "", nil},
 	{`{{dne}}`, User{"Mike", 1}, "", nil},
 	{`{{dne}}`, &User{"Mike", 1}, "", nil},
-	//dotted names(dot notation)
+	// dotted names(dot notation)
 	{`"{{a.b.c}}" == ""`, map[string]interface{}{}, `"" == ""`, nil},
 	{`"{{a.b.c.name}}" == ""`, map[string]interface{}{"a": map[string]interface{}{"b": map[string]string{}}, "c": map[string]string{"name": "Jim"}}, `"" == ""`, nil},
 	{`{{#a}}{{b.c}}{{/a}}`, map[string]interface{}{"a": map[string]interface{}{"b": map[string]string{}}, "b": map[string]string{"c": "ERROR"}}, "", nil},
@@ -459,7 +460,7 @@ var malformed = []Test{
 	{`{{}}`, nil, "", fmt.Errorf("line 1: empty tag")},
 	{`{{}`, nil, "", fmt.Errorf("line 1: unmatched open tag")},
 	{`{{`, nil, "", fmt.Errorf("line 1: unmatched open tag")},
-	//invalid syntax - https://github.com/hoisie/mustache/issues/10
+	// invalid syntax - https://github.com/hoisie/mustache/issues/10
 	{`{{#a}}{{#b}}{{/a}}{{/b}}}`, map[string]interface{}{}, "", fmt.Errorf("line 1: interleaved closing tag: a")},
 }
 
@@ -665,6 +666,44 @@ var tagTests = []tagsTest{
 			},
 		},
 	},
+}
+
+type FakeLookup struct {
+	vars []string
+}
+
+func (f *FakeLookup) Lookup(name string) (reflect.Value, error) {
+	f.vars = append(f.vars, name)
+	return reflect.ValueOf(name), nil
+}
+
+func (f *FakeLookup) List() []string {
+	return f.vars
+}
+
+func TestLookup(t *testing.T) {
+	mt, err := ParseString(`
+			{{var1}}
+			{{var2}}
+	`)
+	if err != nil {
+		t.Error(err)
+	}
+	sl := FakeLookup{}
+	_, err = mt.Render(&sl)
+	if err != nil {
+		t.Error(err)
+	}
+	varList := sl.List()
+	if len(varList) != 2 {
+		t.Error("expected 2 variables got", len(varList))
+	}
+	if varList[0] != "var1" {
+		t.Error("expected var1 got", varList[0])
+	}
+	if varList[1] != "var2" {
+		t.Error("expected var2 got", varList[1])
+	}
 }
 
 func TestTags(t *testing.T) {


### PR DESCRIPTION
This PR adds a special interface `CustomLookup` that allows the caller of Render to manage the context lookup in its own methods.

I included a small unit test that demonstrates (a dumbed down) usage where this mechanism can be used to extract variables from a template and list them.