### PR TITLE
Prevent stack overflow from deeply nested sections

### DIFF
--- a/depth_test.go
+++ b/depth_test.go
@@ -1,0 +1,32 @@
+package mustache
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestDeeplyNestedSectionsDoNotOverflow ensures that a template consisting of a
+// large number of nested section openers is rejected with an error instead of
+// exhausting the goroutine stack and aborting the process.
+func TestDeeplyNestedSectionsDoNotOverflow(t *testing.T) {
+	tmpl := strings.Repeat("{{#a}}", maxNestingDepth+1)
+	_, err := ParseString(tmpl)
+	if err == nil {
+		t.Fatal("expected an error for excessively nested sections, got nil")
+	}
+	var perr ParseError
+	if !errors.As(err, &perr) || perr.Code != ErrNestingTooDeep {
+		t.Fatalf("expected ErrNestingTooDeep, got %v", err)
+	}
+}
+
+// TestReasonablyNestedSectionsStillParse ensures the depth guard does not
+// reject templates with ordinary (well-formed, closed) nesting.
+func TestReasonablyNestedSectionsStillParse(t *testing.T) {
+	const depth = 50
+	tmpl := strings.Repeat("{{#a}}", depth) + "x" + strings.Repeat("{{/a}}", depth)
+	if _, err := ParseString(tmpl); err != nil {
+		t.Fatalf("valid nested template failed to parse: %v", err)
+	}
+}

--- a/error.go
+++ b/error.go
@@ -15,6 +15,7 @@ const (
 	ErrInterleavedClosingTag ErrorCode = "interleaved_closing_tag"
 	ErrInvalidMetaTag        ErrorCode = "invalid_meta_tag"
 	ErrUnmatchedCloseTag     ErrorCode = "unmatched_close_tag"
+	ErrNestingTooDeep        ErrorCode = "nesting_too_deep"
 )
 
 // ParseError represents an error during the parsing
@@ -45,6 +46,8 @@ func (e ParseError) defaultMessage() string {
 		return "Invalid meta tag"
 	case ErrUnmatchedCloseTag:
 		return "unmatched close tag"
+	case ErrNestingTooDeep:
+		return "nesting too deep"
 	default:
 		return "unknown error"
 	}

--- a/mustache.go
+++ b/mustache.go
@@ -47,6 +47,13 @@ const (
 	SkipWhitespaceTagTypes = "#^/<>=!"
 )
 
+// maxNestingDepth bounds how deeply sections may be nested. Parsing recurses
+// once per open section tag, so without a limit a template consisting solely of
+// nested section openers (e.g. many "{{#a}}") would recurse until the goroutine
+// stack is exhausted, aborting the process with an unrecoverable stack
+// overflow. The limit is far larger than any legitimate template requires.
+const maxNestingDepth = 10000
+
 func (t TagType) String() string {
 	if int(t) < len(tagNames) {
 		return tagNames[t]
@@ -324,7 +331,10 @@ func (tmpl *Template) parsePartial(name, indent string) (*partialElement, error)
 	}, nil
 }
 
-func (tmpl *Template) parseSection(section *sectionElement) error {
+func (tmpl *Template) parseSection(section *sectionElement, depth int) error {
+	if depth > maxNestingDepth {
+		return newErrorWithReason(tmpl.curline, ErrNestingTooDeep, section.name)
+	}
 	for {
 		textResult, err := tmpl.readText()
 		text := textResult.text
@@ -355,7 +365,7 @@ func (tmpl *Template) parseSection(section *sectionElement) error {
 		case '#', '^':
 			name := strings.TrimSpace(tag[1:])
 			se := sectionElement{name, tag[0] == '^', tmpl.curline, []interface{}{}}
-			err := tmpl.parseSection(&se)
+			err := tmpl.parseSection(&se, depth+1)
 			if err != nil {
 				return err
 			}
@@ -422,7 +432,7 @@ func (tmpl *Template) parse() error {
 		case '#', '^':
 			name := strings.TrimSpace(tag[1:])
 			se := sectionElement{name, tag[0] == '^', tmpl.curline, []interface{}{}}
-			err := tmpl.parseSection(&se)
+			err := tmpl.parseSection(&se, 1)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Parsing a template recurses once per open section tag: `parseSection` calls itself for every `{{#...}}` / `{{^...}}` it encounters. There is no bound on that recursion, so a template made up of a large number of section openers drives the parser to recurse until the goroutine stack is exhausted.

When that happens Go aborts with `fatal error: stack overflow`, which is **not** a normal `panic` and cannot be caught with `recover()` — it takes down the whole process. Any program that parses untrusted templates through the documented entry points (`ParseString`, `Render`, and friends) can therefore be crashed by a single crafted string.

Minimal reproducer:

```go
package main

import (
    "strings"

    "github.com/cbroglie/mustache"
)

func main() {
    // no closing tags needed; the crash happens during parsing
    mustache.ParseString(strings.Repeat("{{#a}}", 4_000_000))
}
```

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow
...
github.com/cbroglie/mustache.(*Template).parseSection(...)
github.com/cbroglie/mustache.(*Template).parseSection(...)
...
```

### Fix

Thread a depth counter through `parseSection` and return an ordinary parse error (`ErrNestingTooDeep`) once the nesting exceeds a generous limit (10000). Real templates never approach that depth, so well-formed input — including deeply-but-reasonably nested sections — is unaffected, while a hostile template now yields a normal error instead of crashing the process.

Added tests cover both sides: excessive nesting now returns `ErrNestingTooDeep`, and ordinary nested (properly closed) sections still parse. The full suite, including the upstream mustache spec conformance tests, passes.